### PR TITLE
fix(nodeclass): scope orphan cleanup to cluster ID

### DIFF
--- a/cmd/karpenter-exoscale/main.go
+++ b/cmd/karpenter-exoscale/main.go
@@ -87,7 +87,7 @@ func run(ctx context.Context, ctxOp context.Context, op *operator.Operator) erro
 		op.InstanceTypeStore,
 	)
 
-	if err := registerControllers(op.Manager, exoClient, instanceProvider, templateResolver, options.ClusterID, options.Zone); err != nil {
+	if err := registerControllers(op.Manager, exoClient, instanceProvider, templateResolver, options.Zone, options.ClusterID); err != nil {
 		return fmt.Errorf("failed to register custom controllers: %w", err)
 	}
 
@@ -96,7 +96,7 @@ func run(ctx context.Context, ctxOp context.Context, op *operator.Operator) erro
 	return nil
 }
 
-func registerControllers(mgr ctrl.Manager, exoClient *egov3.Client, instanceProvider *instance.Provider, templateResolver *template.Provider, clusterID, zone string) error {
+func registerControllers(mgr ctrl.Manager, exoClient *egov3.Client, instanceProvider *instance.Provider, templateResolver *template.Provider, zone, clusterID string) error {
 	if err := (&bootstraptoken.Controller{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),

--- a/cmd/karpenter-exoscale/main.go
+++ b/cmd/karpenter-exoscale/main.go
@@ -87,7 +87,7 @@ func run(ctx context.Context, ctxOp context.Context, op *operator.Operator) erro
 		op.InstanceTypeStore,
 	)
 
-	if err := registerControllers(op.Manager, exoClient, instanceProvider, templateResolver, options.Zone); err != nil {
+	if err := registerControllers(op.Manager, exoClient, instanceProvider, templateResolver, options.ClusterID, options.Zone); err != nil {
 		return fmt.Errorf("failed to register custom controllers: %w", err)
 	}
 
@@ -96,7 +96,7 @@ func run(ctx context.Context, ctxOp context.Context, op *operator.Operator) erro
 	return nil
 }
 
-func registerControllers(mgr ctrl.Manager, exoClient *egov3.Client, instanceProvider *instance.Provider, templateResolver *template.Provider, zone string) error {
+func registerControllers(mgr ctrl.Manager, exoClient *egov3.Client, instanceProvider *instance.Provider, templateResolver *template.Provider, clusterID, zone string) error {
 	if err := (&bootstraptoken.Controller{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -111,6 +111,7 @@ func registerControllers(mgr ctrl.Manager, exoClient *egov3.Client, instanceProv
 		ExoscaleClient:   exoClient,
 		TemplateResolver: templateResolver,
 		Recorder:         mgr.GetEventRecorderFor("nodeclass-controller"),
+		ClusterID:        clusterID,
 		Zone:             zone,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create nodeclass controller: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exoscale/karpenter-provider-exoscale
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/awslabs/operatorpkg v0.0.0-20251222193911-34e9a1898737

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -53,6 +53,7 @@ type ExoscaleNodeClassReconciler struct {
 	ExoscaleClient   ExoscaleClient
 	TemplateResolver template.Resolver
 	Recorder         record.EventRecorder
+	ClusterID        string
 	Zone             string
 	aagCache         utils.ResourceCache[egov3.AntiAffinityGroup]
 	sgCache          utils.ResourceCache[egov3.SecurityGroup]
@@ -250,6 +251,10 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("nodeclass", nodeClass.Name))
 	log.FromContext(ctx).V(1).Info("checking for orphaned instances")
 
+	if r.ClusterID == "" {
+		return fmt.Errorf("cluster ID is not configured")
+	}
+
 	instances, err := r.ExoscaleClient.ListInstances(ctx)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to list instances")
@@ -269,12 +274,7 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 
 	orphanedCount := 0
 	for _, inst := range instances.Instances {
-		if inst.Labels == nil {
-			continue
-		}
-
-		managedBy, hasManagedBy := inst.Labels[constants.InstanceLabelManagedBy]
-		if !hasManagedBy || managedBy != constants.ManagedByKarpenter {
+		if !r.isManagedInstanceForCluster(inst) {
 			continue
 		}
 
@@ -311,6 +311,20 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 	}
 
 	return nil
+}
+
+func (r *ExoscaleNodeClassReconciler) isManagedInstanceForCluster(inst egov3.ListInstancesResponseInstances) bool {
+	if inst.Labels == nil {
+		return false
+	}
+
+	managedBy, hasManagedBy := inst.Labels[constants.InstanceLabelManagedBy]
+	if !hasManagedBy || managedBy != constants.ManagedByKarpenter {
+		return false
+	}
+
+	clusterID, hasClusterID := inst.Labels[constants.InstanceLabelClusterID]
+	return hasClusterID && clusterID == r.ClusterID
 }
 
 func (r *ExoscaleNodeClassReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -274,10 +274,6 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 
 	orphanedCount := 0
 	for _, inst := range instances.Instances {
-		if !r.isManagedInstanceForCluster(inst) {
-			continue
-		}
-
 		nodeClaimName, isOrphanedNodeClaim := r.orphanedNodeClaimName(inst, validNodeClaims)
 		if !isOrphanedNodeClaim {
 			continue
@@ -314,7 +310,17 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 }
 
 func (r *ExoscaleNodeClassReconciler) orphanedNodeClaimName(inst egov3.ListInstancesResponseInstances, validNodeClaims map[string]bool) (string, bool) {
-	if !r.isManagedInstanceForCluster(inst) {
+	if inst.Labels == nil {
+		return "", false
+	}
+
+	managedBy, hasManagedBy := inst.Labels[constants.InstanceLabelManagedBy]
+	if !hasManagedBy || managedBy != constants.ManagedByKarpenter {
+		return "", false
+	}
+
+	clusterID, hasClusterID := inst.Labels[constants.InstanceLabelClusterID]
+	if !hasClusterID || clusterID != r.ClusterID {
 		return "", false
 	}
 
@@ -324,20 +330,6 @@ func (r *ExoscaleNodeClassReconciler) orphanedNodeClaimName(inst egov3.ListInsta
 	}
 
 	return nodeClaimName, true
-}
-
-func (r *ExoscaleNodeClassReconciler) isManagedInstanceForCluster(inst egov3.ListInstancesResponseInstances) bool {
-	if inst.Labels == nil {
-		return false
-	}
-
-	managedBy, hasManagedBy := inst.Labels[constants.InstanceLabelManagedBy]
-	if !hasManagedBy || managedBy != constants.ManagedByKarpenter {
-		return false
-	}
-
-	clusterID, hasClusterID := inst.Labels[constants.InstanceLabelClusterID]
-	return hasClusterID && clusterID == r.ClusterID
 }
 
 func (r *ExoscaleNodeClassReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -278,8 +278,8 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 			continue
 		}
 
-		nodeClaimName, hasNodeClaim := inst.Labels[constants.InstanceLabelNodeClaim]
-		if !hasNodeClaim || validNodeClaims[nodeClaimName] {
+		nodeClaimName, isOrphanedNodeClaim := r.orphanedNodeClaimName(inst, validNodeClaims)
+		if !isOrphanedNodeClaim {
 			continue
 		}
 
@@ -311,6 +311,19 @@ func (r *ExoscaleNodeClassReconciler) cleanupOrphanedInstances(ctx context.Conte
 	}
 
 	return nil
+}
+
+func (r *ExoscaleNodeClassReconciler) orphanedNodeClaimName(inst egov3.ListInstancesResponseInstances, validNodeClaims map[string]bool) (string, bool) {
+	if !r.isManagedInstanceForCluster(inst) {
+		return "", false
+	}
+
+	nodeClaimName, hasNodeClaim := inst.Labels[constants.InstanceLabelNodeClaim]
+	if !hasNodeClaim || validNodeClaims[nodeClaimName] {
+		return "", false
+	}
+
+	return nodeClaimName, true
 }
 
 func (r *ExoscaleNodeClassReconciler) isManagedInstanceForCluster(inst egov3.ListInstancesResponseInstances) bool {

--- a/pkg/controllers/nodeclass/controller_test.go
+++ b/pkg/controllers/nodeclass/controller_test.go
@@ -1,12 +1,21 @@
 package nodeclass
 
 import (
+	"context"
+	"reflect"
 	"strings"
 	"testing"
 
+	egov3 "github.com/exoscale/egoscale/v3"
 	apiv1 "github.com/exoscale/karpenter-provider-exoscale/apis/karpenter/v1"
+	"github.com/exoscale/karpenter-provider-exoscale/pkg/constants"
+	"github.com/exoscale/karpenter-provider-exoscale/pkg/providers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/karpenter/pkg/apis"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
@@ -423,5 +432,88 @@ func TestValidateSpec(t *testing.T) {
 				t.Errorf("validateSpec() error = %v, want error containing %v", err, tt.errContains)
 			}
 		})
+	}
+}
+
+func TestCleanupOrphanedInstancesOnlyDeletesInstancesForCurrentCluster(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = apiv1.AddToScheme(scheme)
+	gv := schema.GroupVersion{Group: apis.Group, Version: "v1"}
+	scheme.AddKnownTypes(gv, &karpenterv1.NodeClaim{}, &karpenterv1.NodeClaimList{})
+	metav1.AddToGroupVersion(scheme, gv)
+
+	nodeClass := &apiv1.ExoscaleNodeClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-node",
+		},
+	}
+	activeNodeClaim := &karpenterv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-b-worker-active",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(nodeClass, activeNodeClaim).
+		Build()
+
+	deletedIDs := make([]egov3.UUID, 0)
+	reconciler := &ExoscaleNodeClassReconciler{
+		Client:    fakeClient,
+		Scheme:    scheme,
+		Recorder:  record.NewFakeRecorder(10),
+		ClusterID: "cluster-b-id",
+		ExoscaleClient: &providers.MockClient{
+			ListInstancesFunc: func(ctx context.Context, opts ...egov3.ListInstancesOpt) (*egov3.ListInstancesResponse, error) {
+				return &egov3.ListInstancesResponse{
+					Instances: []egov3.ListInstancesResponseInstances{
+						{
+							ID:   egov3.UUID("11111111-1111-1111-1111-111111111111"),
+							Name: "k-cluster-b-worker-orphan",
+							Labels: map[string]string{
+								constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+								constants.InstanceLabelClusterID: "cluster-b-id",
+								constants.InstanceLabelNodeClaim: "cluster-b-worker-missing",
+							},
+						},
+						{
+							ID:   egov3.UUID("22222222-2222-2222-2222-222222222222"),
+							Name: "k-cluster-a-worker",
+							Labels: map[string]string{
+								constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+								constants.InstanceLabelClusterID: "cluster-a-id",
+								constants.InstanceLabelNodeClaim: "cluster-a-worker",
+							},
+						},
+						{
+							ID:   egov3.UUID("33333333-3333-3333-3333-333333333333"),
+							Name: "k-cluster-b-worker-active",
+							Labels: map[string]string{
+								constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+								constants.InstanceLabelClusterID: "cluster-b-id",
+								constants.InstanceLabelNodeClaim: "cluster-b-worker-active",
+							},
+						},
+					},
+				}, nil
+			},
+			DeleteInstanceFunc: func(ctx context.Context, id egov3.UUID) (*egov3.Operation, error) {
+				deletedIDs = append(deletedIDs, id)
+				return &egov3.Operation{}, nil
+			},
+		},
+	}
+
+	err := reconciler.cleanupOrphanedInstances(context.Background(), nodeClass)
+	if err != nil {
+		t.Fatalf("cleanupOrphanedInstances() unexpected error = %v", err)
+	}
+
+	wantDeleted := []egov3.UUID{
+		egov3.UUID("11111111-1111-1111-1111-111111111111"),
+	}
+	if !reflect.DeepEqual(deletedIDs, wantDeleted) {
+		t.Fatalf("cleanupOrphanedInstances() deleted IDs = %v, want %v", deletedIDs, wantDeleted)
 	}
 }

--- a/pkg/controllers/nodeclass/controller_test.go
+++ b/pkg/controllers/nodeclass/controller_test.go
@@ -517,3 +517,114 @@ func TestCleanupOrphanedInstancesOnlyDeletesInstancesForCurrentCluster(t *testin
 		t.Fatalf("cleanupOrphanedInstances() deleted IDs = %v, want %v", deletedIDs, wantDeleted)
 	}
 }
+
+func TestOrphanedNodeClaimName(t *testing.T) {
+	reconciler := &ExoscaleNodeClassReconciler{
+		ClusterID: "cluster-b-id",
+	}
+
+	tests := []struct {
+		name            string
+		instance        egov3.ListInstancesResponseInstances
+		validNodeClaims map[string]bool
+		wantName        string
+		wantOK          bool
+	}{
+		{
+			name:            "rejects instance without labels",
+			instance:        egov3.ListInstancesResponseInstances{},
+			validNodeClaims: map[string]bool{},
+			wantName:        "",
+			wantOK:          false,
+		},
+		{
+			name: "rejects instance not managed by karpenter",
+			instance: egov3.ListInstancesResponseInstances{
+				Labels: map[string]string{
+					constants.InstanceLabelManagedBy: "someone-else",
+					constants.InstanceLabelClusterID: "cluster-b-id",
+					constants.InstanceLabelNodeClaim: "cluster-b-worker-missing",
+				},
+			},
+			validNodeClaims: map[string]bool{},
+			wantName:        "",
+			wantOK:          false,
+		},
+		{
+			name: "rejects instance without cluster id",
+			instance: egov3.ListInstancesResponseInstances{
+				Labels: map[string]string{
+					constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+					constants.InstanceLabelNodeClaim: "cluster-b-worker-missing",
+				},
+			},
+			validNodeClaims: map[string]bool{},
+			wantName:        "",
+			wantOK:          false,
+		},
+		{
+			name: "rejects instance from another cluster",
+			instance: egov3.ListInstancesResponseInstances{
+				Labels: map[string]string{
+					constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+					constants.InstanceLabelClusterID: "cluster-a-id",
+					constants.InstanceLabelNodeClaim: "cluster-a-worker",
+				},
+			},
+			validNodeClaims: map[string]bool{},
+			wantName:        "",
+			wantOK:          false,
+		},
+		{
+			name: "rejects instance without nodeclaim label",
+			instance: egov3.ListInstancesResponseInstances{
+				Labels: map[string]string{
+					constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+					constants.InstanceLabelClusterID: "cluster-b-id",
+				},
+			},
+			validNodeClaims: map[string]bool{},
+			wantName:        "",
+			wantOK:          false,
+		},
+		{
+			name: "rejects instance with existing nodeclaim in current cluster",
+			instance: egov3.ListInstancesResponseInstances{
+				Labels: map[string]string{
+					constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+					constants.InstanceLabelClusterID: "cluster-b-id",
+					constants.InstanceLabelNodeClaim: "cluster-b-worker-active",
+				},
+			},
+			validNodeClaims: map[string]bool{
+				"cluster-b-worker-active": true,
+			},
+			wantName: "",
+			wantOK:   false,
+		},
+		{
+			name: "returns orphaned nodeclaim for current cluster",
+			instance: egov3.ListInstancesResponseInstances{
+				Labels: map[string]string{
+					constants.InstanceLabelManagedBy: constants.ManagedByKarpenter,
+					constants.InstanceLabelClusterID: "cluster-b-id",
+					constants.InstanceLabelNodeClaim: "cluster-b-worker-missing",
+				},
+			},
+			validNodeClaims: map[string]bool{
+				"cluster-b-worker-active": true,
+			},
+			wantName: "cluster-b-worker-missing",
+			wantOK:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotOK := reconciler.orphanedNodeClaimName(tt.instance, tt.validNodeClaims)
+			if gotName != tt.wantName || gotOK != tt.wantOK {
+				t.Fatalf("orphanedNodeClaimName() = (%q, %v), want (%q, %v)", gotName, gotOK, tt.wantName, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fix cross-cluster orphan cleanup during `ExoscaleNodeClass` teardown.

The nodeclass controller was listing all Karpenter-managed instances visible to the role and deleting any whose `nodeclaim` label was not present in the local cluster. This bypassed the existing cluster scoping already implemented in the instance provider, which could allow one cluster to delete instances from another cluster in the same zone.

This change wires the current cluster ID into the nodeclass reconciler and filters orphan cleanup candidates by `exoscale.com/cluster-id` before deletion. A regression test is included for the `cluster-a` / `cluster-b` case.

Related to #128

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

- `go test ./pkg/controllers/nodeclass ./pkg/providers/instance`
