### PR TITLE
feat: permit to enable IPv6 on compute instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 UNRELEASED
 ------------------
 
+- feat: add compute instances IPv6 support
+
 1.35.0
 ------------------
 

--- a/apis/karpenter/v1/exoscalenodeclass_types.go
+++ b/apis/karpenter/v1/exoscalenodeclass_types.go
@@ -104,6 +104,10 @@ type ExoscaleNodeClassSpec struct {
 	// Kubelet contains configuration for kubelet
 	// +optional
 	Kubelet KubeletConfiguration `json:"kubelet,omitempty"`
+
+	// EnableIPv6 indicates whether to enable IPv6 for instances created with this NodeClass
+	// +optional
+	EnableIPv6 bool `json:"enableIPv6,omitempty"`
 }
 
 type KubeletConfiguration struct {

--- a/config/crd/bases/karpenter.exoscale.com_exoscalenodeclasses.yaml
+++ b/config/crd/bases/karpenter.exoscale.com_exoscalenodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: exoscalenodeclasses.karpenter.exoscale.com
 spec:
   group: karpenter.exoscale.com
@@ -79,6 +79,10 @@ spec:
                 maximum: 8000
                 minimum: 10
                 type: integer
+              enableIPv6:
+                description: EnableIPv6 indicates whether to enable IPv6 for instances
+                  created with this NodeClass
+                type: boolean
               imageTemplateSelector:
                 properties:
                   variant:

--- a/config/crd/bases/kustomization.yaml
+++ b/config/crd/bases/kustomization.yaml
@@ -2,7 +2,7 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-  - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/refs/tags/v1.9.0/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/refs/tags/v1.9.0/pkg/apis/crds/karpenter.sh_nodepools.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/refs/tags/v1.9.0/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/refs/tags/v1.12.0/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/refs/tags/v1.12.0/pkg/apis/crds/karpenter.sh_nodepools.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/refs/tags/v1.12.0/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
   - karpenter.exoscale.com_exoscalenodeclasses.yaml

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -29,6 +29,7 @@ const (
 	DriftReasonAntiAffinityGroups cloudprovider.DriftReason = "AntiAffinityGroups"
 	DriftReasonSecurityGroups     cloudprovider.DriftReason = "SecurityGroups"
 	DriftReasonPrivateNetworks    cloudprovider.DriftReason = "PrivateNetworks"
+	DriftReasonIPv6               cloudprovider.DriftReason = "IPv6ToggleDrift"
 )
 
 type CloudProvider struct {
@@ -233,6 +234,19 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpenterv1.No
 		c.publishEvent(nodeClaim, v1.EventTypeNormal, "DriftDetected",
 			fmt.Sprintf("Instance template ID drift detected: nodeClaim ImageID %s != instance Template ID %s", nodeClaim.Status.ImageID, inst.Template.ID))
 		return DriftReasonImageID, nil
+	}
+
+	// Verify if IPv6 enable is compliant with instance reported addresses
+	if nodeClass.Spec.EnableIPv6 && !utils.ContainsIPv6Address(inst.Addresses) {
+		log.FromContext(ctx).Info("detected IPv6 drift", "reason", DriftReasonIPv6)
+		c.publishEvent(nodeClaim, v1.EventTypeNormal, "DriftDetected",
+			"Instance IPv6 drift detected: nodeClass EnableIPv6 is true but instance doesn't have any IPv6Address")
+		return DriftReasonIPv6, nil
+	} else if !nodeClass.Spec.EnableIPv6 && utils.ContainsIPv6Address(inst.Addresses) {
+		log.FromContext(ctx).Info("detected IPv6 drift", "reason", DriftReasonIPv6)
+		c.publishEvent(nodeClaim, v1.EventTypeNormal, "DriftDetected",
+			"Instance IPv6 drift detected: nodeClass EnableIPv6 is false but instance has IPv6Address")
+		return DriftReasonIPv6, nil
 	}
 
 	left, right := lo.Difference(nodeClass.Status.AntiAffinityGroups, inst.AntiAffinityGroups)

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -70,6 +70,17 @@ func FromExoscaleInstance(instance *egov3.Instance, instanceType *cloudprovider.
 		})
 	}
 
+	if instance.Ipv6Address != "" {
+		i.Addresses = append(i.Addresses, v1.NodeAddress{
+			Type:    v1.NodeExternalIP,
+			Address: instance.Ipv6Address,
+		})
+		i.Addresses = append(i.Addresses, v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: instance.Ipv6Address,
+		})
+	}
+
 	family := string(instance.InstanceType.Family)
 	size := string(instance.InstanceType.Size)
 	i.InstanceTypeName = family + "." + size

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -73,11 +73,12 @@ func TestFromExoscaleInstance_WithAddresses(t *testing.T) {
 	zone := "ch-gva-2"
 
 	exoInstance := &egov3.Instance{
-		ID:       egov3.UUID(instanceID),
-		Name:     instanceName,
-		State:    egov3.InstanceStateRunning,
-		DiskSize: 50,
-		PublicIP: net.IP{192, 168, 1, 100},
+		ID:          egov3.UUID(instanceID),
+		Name:        instanceName,
+		State:       egov3.InstanceStateRunning,
+		DiskSize:    50,
+		PublicIP:    net.IP{192, 168, 1, 100},
+		Ipv6Address: "fe80::1:2:3",
 		Labels: map[string]string{
 			constants.InstanceLabelNodeClaim: "test-claim-with-ip",
 		},
@@ -105,8 +106,8 @@ func TestFromExoscaleInstance_WithAddresses(t *testing.T) {
 	}
 
 	// Verify we have exactly 3 addresses
-	if len(got.Addresses) != 3 {
-		t.Fatalf("FromExoscaleInstance() Addresses count = %d, want 3", len(got.Addresses))
+	if len(got.Addresses) != 5 {
+		t.Fatalf("FromExoscaleInstance() Addresses count = %d, want 5", len(got.Addresses))
 	}
 
 	// Verify we have a default Hostname
@@ -132,6 +133,23 @@ func TestFromExoscaleInstance_WithAddresses(t *testing.T) {
 	}
 	if got.Addresses[2].Address != expectedIP {
 		t.Errorf("Addresses[2].Address = %v, want %v", got.Addresses[2].Address, expectedIP)
+	}
+
+	// Verify the external IPv6 address
+	expectedIPv6 := "fe80::1:2:3"
+	if got.Addresses[3].Type != v1.NodeExternalIP {
+		t.Errorf("Addresses[3].Type = %v, want %v", got.Addresses[3].Type, v1.NodeExternalIP)
+	}
+	if got.Addresses[3].Address != expectedIPv6 {
+		t.Errorf("Addresses[3].Address = %v, want %v", got.Addresses[3].Address, expectedIPv6)
+	}
+
+	// Verify the internal IPv6 address (same as external)
+	if got.Addresses[4].Type != v1.NodeInternalIP {
+		t.Errorf("Addresses[4].Type = %v, want %v", got.Addresses[4].Type, v1.NodeInternalIP)
+	}
+	if got.Addresses[4].Address != expectedIPv6 {
+		t.Errorf("Addresses[4].Address = %v, want %v", got.Addresses[4].Address, expectedIPv6)
 	}
 }
 

--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -109,6 +109,11 @@ func (p *Provider) Create(ctx context.Context, nodeClass *apiv1.ExoscaleNodeClas
 		Labels:             p.GenerateInstanceLabels(nodeClaim),
 		SecurityGroups:     p.convertSecurityGroups(nodeClass.Status.SecurityGroups),
 		AntiAffinityGroups: p.convertAntiAffinityGroups(nodeClass.Status.AntiAffinityGroups),
+		Ipv6Enabled:        &nodeClass.Spec.EnableIPv6,
+	}
+
+	if nodeClass.Spec.EnableIPv6 {
+		createRequest.PublicIPAssignment = egov3.PublicIPAssignmentDual
 	}
 
 	createCtx, cancel := context.WithTimeout(ctx, constants.DefaultOperationTimeout)

--- a/pkg/utils/provider.go
+++ b/pkg/utils/provider.go
@@ -2,8 +2,12 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"regexp"
+	"slices"
 	"strings"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 const ExoscaleProviderIDPrefix = "exoscale://"
@@ -25,4 +29,11 @@ func ParseProviderID(providerID string) (string, error) {
 	}
 
 	return instanceID, nil
+}
+
+func ContainsIPv6Address(addresses []v1.NodeAddress) bool {
+	return slices.ContainsFunc(addresses, func(addr v1.NodeAddress) bool {
+		ip := net.ParseIP(addr.Address)
+		return ip != nil && ip.To4() == nil
+	})
 }

--- a/pkg/utils/provider_test.go
+++ b/pkg/utils/provider_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestParseProviderID(t *testing.T) {
@@ -52,6 +54,66 @@ func TestParseProviderID(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ParseProviderID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsIPv6Address(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []v1.NodeAddress
+		want      bool
+	}{
+		{
+			name: "contains valid IPv6",
+			addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "192.168.1.1"},
+				{Type: v1.NodeInternalIP, Address: "2001:db8::1"},
+			},
+			want: true,
+		},
+		{
+			name: "only IPv4",
+			addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "192.168.1.1"},
+				{Type: v1.NodeExternalIP, Address: "1.2.3.4"},
+			},
+			want: false,
+		},
+		{
+			name: "only IPv6",
+			addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "fe80::1"},
+			},
+			want: true,
+		},
+		{
+			name:      "empty list",
+			addresses: []v1.NodeAddress{},
+			want:      false,
+		},
+		{
+			name: "invalid address is not counted as IPv6",
+			addresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: "not:an:ip"},
+			},
+			want: false,
+		},
+		{
+			name: "IPv4-mapped IPv6 address",
+			addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "::ffff:192.0.2.1"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContainsIPv6Address(tt.addresses)
+			if got != tt.want {
+				t.Errorf("ContainsIPv6Address() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

IPv6 was not supported before this PR. Now users can use IPv6 with karpenter on their clusters

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

Drift detection
```

{"level":"INFO","time":"2026-05-05T16:23:27.643+0200","logger":"controller","message":"detected IPv6 drift","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"system-ltnzw"},"namespace":"","name":"system-ltnzw","reconcileID":"830ffded-1b64-4a82-a342-4464381c733c","Node":{"name":"k-system-ltnzw"},"method":"IsDrifted","nodeClaim":"system-ltnzw","providerID":"exoscale://38cdb13f-12e8-45e3-9c14-4335c5bc8b35","reason":"IPv6ToggleDrift"}
```

Instance with IPv6 enabled
<img width="1691" height="1079" alt="image" src="https://github.com/user-attachments/assets/4a4595b6-7805-4a0f-a24b-7b54d82d590c" />

