### PR TITLE
Implement more drift/gc mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 ------------------
 
 - feat: add support for custom user-data configuration (#122)
+- fix(drift): skip drift detection for instances that are still provisioning
+- fix(gc): do not delete instances that are still being provisioned
+- fix(node): make Node pre-creation idempotent to avoid "node already exists" failures
 - fix(deps): update module sigs.k8s.io/karpenter to v1.12.1 (#137)
 - fix(deps): update module github.com/exoscale/egoscale/v3 to v3.1.37 (#137)
 

--- a/cmd/karpenter-exoscale/main.go
+++ b/cmd/karpenter-exoscale/main.go
@@ -119,6 +119,7 @@ func registerControllers(mgr ctrl.Manager, exoClient *egov3.Client, instanceProv
 
 	if err := garbagecollection.StartController(mgr, &garbagecollection.Controller{
 		Client:           mgr.GetClient(),
+		APIReader:        mgr.GetAPIReader(),
 		InstanceProvider: instanceProvider,
 	}); err != nil {
 		return fmt.Errorf("unable to create garbage collection controller: %w", err)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -415,10 +415,50 @@ func (c *CloudProvider) createNode(ctx context.Context, nodeClaim *karpenterv1.N
 	}
 
 	if err := c.kubeClient.Create(ctx, node); err != nil {
-		return fmt.Errorf("creating node %s: %w", nodeName, err)
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating node %s: %w", nodeName, err)
+		}
+		// The Node already exists.
+		if err := c.ensureNodeIdentity(ctx, nodeName, node); err != nil {
+			return err
+		}
+		log.FromContext(ctx).Info("reconciled existing node", "nodeName", nodeName)
+		return nil
 	}
 
 	log.FromContext(ctx).Info("created Pending node", "nodeName", nodeName)
+	return nil
+}
+
+// ensureNodeIdentity patches the CCM-critical identity onto an already-existing Node so
+// it stays resolvable: Spec.ProviderID (the kubelet registers with an empty ProviderID
+// under cloud-provider=external) and Status.NodeInfo.SystemUUID / Addresses (the
+// identifier the Exoscale CCM looks the instance up by).
+func (c *CloudProvider) ensureNodeIdentity(ctx context.Context, nodeName string, desired *v1.Node) error {
+	existing := &v1.Node{}
+	if err := c.kubeClient.Get(ctx, client.ObjectKey{Name: nodeName}, existing); err != nil {
+		return fmt.Errorf("getting existing node %s: %w", nodeName, err)
+	}
+
+	if existing.Spec.ProviderID == "" {
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Spec.ProviderID = desired.Spec.ProviderID
+		if err := c.kubeClient.Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("patching node %s provider ID: %w", nodeName, err)
+		}
+	}
+
+	if existing.Status.NodeInfo.SystemUUID == "" {
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Status.NodeInfo.SystemUUID = desired.Status.NodeInfo.SystemUUID
+		if len(existing.Status.Addresses) == 0 {
+			existing.Status.Addresses = desired.Status.Addresses
+		}
+		if err := c.kubeClient.Status().Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("patching node %s status: %w", nodeName, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -229,6 +229,12 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpenterv1.No
 		return "", err
 	}
 
+	// Only evaluate drift for instances that are fully running.
+	if !inst.IsRunning() {
+		log.FromContext(ctx).V(2).Info("instance not running yet, skipping drift detection", "state", inst.State)
+		return "", nil
+	}
+
 	if nodeClaim.Status.ImageID != inst.Template.ID {
 		log.FromContext(ctx).Info("detected template drift", "reason", DriftReasonImageID)
 		c.publishEvent(nodeClaim, v1.EventTypeNormal, "DriftDetected",

--- a/pkg/controllers/garbagecollection/controller.go
+++ b/pkg/controllers/garbagecollection/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/exoscale/karpenter-provider-exoscale/pkg/constants"
 	"github.com/exoscale/karpenter-provider-exoscale/pkg/providers/instance"
 	"github.com/exoscale/karpenter-provider-exoscale/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,14 +17,21 @@ import (
 )
 
 const (
-	GCInterval               = 5 * time.Minute
-	StuckNodeClaimTimeout    = 10 * time.Minute
-	TerminationFinalizerName = "karpenter.sh/termination"
+	GCInterval                = 5 * time.Minute
+	StuckNodeClaimTimeout     = 10 * time.Minute
+	TerminationFinalizerName  = "karpenter.sh/termination"
+	OrphanInstanceGracePeriod = 15 * time.Minute
 )
 
 type Controller struct {
 	Client           client.Client
 	InstanceProvider *instance.Provider
+
+	// APIReader is an uncached reader used to confirm that an instance really has
+	// no NodeClaim before deleting it. Reading orphan candidates straight from the
+	// API server (rather than the informer cache) avoids deleting a live instance
+	// off a momentarily stale cache view.
+	APIReader client.Reader
 }
 
 func StartController(mgr manager.Manager, gc *Controller) error {
@@ -66,23 +74,41 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 	log.FromContext(ctx).Info("listed cloud instances", "count", len(cloudInstances))
 
+	// Read NodeClaims straight from the API server rather than the informer cache.
 	var nodeClaims karpenterv1.NodeClaimList
-	if err := c.Client.List(ctx, &nodeClaims); err != nil {
+	if err := c.APIReader.List(ctx, &nodeClaims); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to list NodeClaims: %w", err)
 	}
 
 	nodeClaimProviderIDs := make(map[string]bool)
+	nodeClaimNames := make(map[string]bool)
 	for _, nc := range nodeClaims.Items {
+		nodeClaimNames[nc.Name] = true
+
 		instanceID, err := utils.ParseProviderID(nc.Status.ProviderID)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "invalid provider ID in NodeClaim", "nodeClaim", nc.Name)
+			// A NodeClaim whose ProviderID isn't set/parseable yet (e.g. still being
+			// created) is matched by name below instead, so this isn't fatal.
+			log.FromContext(ctx).V(1).Info("NodeClaim has no parseable provider ID yet", "nodeClaim", nc.Name)
 			continue
 		}
 		nodeClaimProviderIDs[instanceID] = true
 	}
 
+	// Delete instances that have no matching NodeClaim. An instance is only a true
+	// orphan when it matches neither by ProviderID nor by node-claim label name
+	// (the name match covers a NodeClaim whose ProviderID isn't populated yet,
+	// e.g. mid-creation) and is past the provisioning grace period (cheap
+	// defense-in-depth against transient races at creation time).
 	for _, inst := range cloudInstances {
-		if nodeClaimProviderIDs[inst.ID] {
+		if hasMatchingNodeClaim(inst, nodeClaimProviderIDs, nodeClaimNames) {
+			continue
+		}
+		if !isOrphanInstanceReapable(inst.CreatedAt, time.Now(), OrphanInstanceGracePeriod) {
+			log.FromContext(ctx).V(1).Info("skipping orphaned instance within grace period",
+				"instanceID", inst.ID,
+				"name", inst.Name,
+				"age", time.Since(inst.CreatedAt))
 			continue
 		}
 
@@ -147,6 +173,30 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	log.FromContext(ctx).Info("garbage collection completed", "stuckNodeClaimsProcessed", stuckCount)
 
 	return reconcile.Result{}, nil
+}
+
+// hasMatchingNodeClaim reports whether a cloud instance still corresponds to a
+// known NodeClaim. It matches first on the NodeClaim ProviderID and then falls
+// back to the instance's node-claim label against the set of NodeClaim names.
+func hasMatchingNodeClaim(inst *instance.Instance, providerIDs, names map[string]bool) bool {
+	if providerIDs[inst.ID] {
+		return true
+	}
+	if name := inst.Labels[constants.InstanceLabelNodeClaim]; name != "" && names[name] {
+		return true
+	}
+	return false
+}
+
+// isOrphanInstanceReapable reports whether an orphaned cloud instance (one with no
+// matching NodeClaim) is old enough to be safely garbage collected. Instances that
+// are younger than gracePeriod or whose creation time is unknown (zero), are
+// spared, to avoid deleting instances that are still being provisioned.
+func isOrphanInstanceReapable(createdAt, now time.Time, gracePeriod time.Duration) bool {
+	if createdAt.IsZero() {
+		return false
+	}
+	return now.Sub(createdAt) >= gracePeriod
 }
 
 func hasTerminationFinalizer(nc *karpenterv1.NodeClaim) bool {

--- a/pkg/controllers/garbagecollection/controller_test.go
+++ b/pkg/controllers/garbagecollection/controller_test.go
@@ -2,10 +2,112 @@ package garbagecollection
 
 import (
 	"testing"
+	"time"
 
+	"github.com/exoscale/karpenter-provider-exoscale/pkg/constants"
+	"github.com/exoscale/karpenter-provider-exoscale/pkg/providers/instance"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
+
+func TestHasMatchingNodeClaim(t *testing.T) {
+	providerIDs := map[string]bool{"i-matched-by-id": true}
+	names := map[string]bool{"claim-existing": true}
+
+	tests := []struct {
+		name string
+		inst *instance.Instance
+		want bool
+	}{
+		{
+			name: "matched by provider id",
+			inst: &instance.Instance{ID: "i-matched-by-id"},
+			want: true,
+		},
+		{
+			name: "matched by node-claim label when provider id not yet known",
+			inst: &instance.Instance{
+				ID:     "i-new",
+				Labels: map[string]string{constants.InstanceLabelNodeClaim: "claim-existing"},
+			},
+			want: true,
+		},
+		{
+			name: "node-claim label points to a missing claim",
+			inst: &instance.Instance{
+				ID:     "i-orphan",
+				Labels: map[string]string{constants.InstanceLabelNodeClaim: "claim-gone"},
+			},
+			want: false,
+		},
+		{
+			name: "no provider id match and no node-claim label",
+			inst: &instance.Instance{ID: "i-orphan-nolabel"},
+			want: false,
+		},
+		{
+			name: "empty node-claim label is ignored",
+			inst: &instance.Instance{
+				ID:     "i-orphan-emptylabel",
+				Labels: map[string]string{constants.InstanceLabelNodeClaim: ""},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasMatchingNodeClaim(tt.inst, providerIDs, names); got != tt.want {
+				t.Errorf("hasMatchingNodeClaim() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsOrphanInstanceReapable(t *testing.T) {
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	grace := OrphanInstanceGracePeriod
+
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		want      bool
+	}{
+		{
+			name:      "freshly created instance is spared",
+			createdAt: now.Add(-30 * time.Second),
+			want:      false,
+		},
+		{
+			name:      "instance just under grace period is spared",
+			createdAt: now.Add(-grace + time.Second),
+			want:      false,
+		},
+		{
+			name:      "instance exactly at grace period is reapable",
+			createdAt: now.Add(-grace),
+			want:      true,
+		},
+		{
+			name:      "old instance is reapable",
+			createdAt: now.Add(-time.Hour),
+			want:      true,
+		},
+		{
+			name:      "unknown creation time is spared",
+			createdAt: time.Time{},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOrphanInstanceReapable(tt.createdAt, now, grace); got != tt.want {
+				t.Errorf("isOrphanInstanceReapable(%v, %v, %v) = %v, want %v", tt.createdAt, now, grace, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestHasTerminationFinalizer(t *testing.T) {
 	tests := []struct {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -118,7 +118,14 @@ func FromExoscaleInstance(instance *egov3.Instance, instanceType *cloudprovider.
 	return i
 }
 
-// ToNodeClaim creates a NodeClaim from the instance
+// IsRunning reports whether the instance is in the running state. Steady-state
+// checks such as drift detection should only run on running instances: a
+// still-provisioning instance (e.g. "starting") may not yet report all of its
+// attached resources — private networks, IPv6 address, etc.
+func (i *Instance) IsRunning() bool {
+	return i.State == egov3.InstanceStateRunning
+}
+
 func (i *Instance) ToNodeClaim() *karpenterv1.NodeClaim {
 	capacity := v1.ResourceList{}
 	allocatable := v1.ResourceList{}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -221,3 +221,28 @@ func TestInstance_ToNodeClaim(t *testing.T) {
 		t.Errorf("ToNodeClaim() capacity type = %v, want %v", got.Labels[karpenterv1.CapacityTypeLabelKey], karpenterv1.CapacityTypeOnDemand)
 	}
 }
+
+func TestInstance_IsRunning(t *testing.T) {
+	tests := []struct {
+		name  string
+		state egov3.InstanceState
+		want  bool
+	}{
+		{name: "running", state: egov3.InstanceStateRunning, want: true},
+		{name: "starting", state: egov3.InstanceStateStarting, want: false},
+		{name: "stopping", state: egov3.InstanceStateStopping, want: false},
+		{name: "stopped", state: egov3.InstanceStateStopped, want: false},
+		{name: "destroying", state: egov3.InstanceStateDestroying, want: false},
+		{name: "error", state: egov3.InstanceStateError, want: false},
+		{name: "empty", state: egov3.InstanceState(""), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Instance{State: tt.state}
+			if got := i.IsRunning(); got != tt.want {
+				t.Errorf("IsRunning() with state %q = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

- Prevent drift on instance still being provisioned
- Prevent GC on instances also still being provisioned
- Node pre-creation is now idempotent

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

New baseline within a cluster (cilium managed), is 2x `standard.small` without any churn.

```
NAME                    STATUS   ROLES    AGE     VERSION
node/k-standard-79d6w   Ready    <none>   3m25s   v1.36.0
node/k-standard-fqxht   Ready    <none>   3m25s   v1.36.0

NAME                                    TYPE             CAPACITY    ZONE       NODE               READY   AGE
nodeclaim.karpenter.sh/standard-79d6w   standard.small   on-demand   hr-zag-1   k-standard-79d6w   True    3m26s
nodeclaim.karpenter.sh/standard-fqxht   standard.small   on-demand   hr-zag-1   k-standard-fqxht   True    3m26s

NAMESPACE     NAME                                           READY   STATUS    RESTARTS        AGE
kube-system   pod/cilium-5qg5j                               1/1     Running   0               3m24s
kube-system   pod/cilium-envoy-mqxb4                         1/1     Running   0               3m24s
kube-system   pod/cilium-envoy-w5n7j                         1/1     Running   0               3m24s
kube-system   pod/cilium-operator-5fdb95db8-vw869            1/1     Running   0               3m58s
kube-system   pod/cilium-operator-5fdb95db8-xx775            1/1     Running   0               3m58s
kube-system   pod/cilium-q4sdv                               1/1     Running   0               3m24s
kube-system   pod/coredns-6cd4f4df4f-b4b9m                   1/1     Running   0               3m58s
kube-system   pod/coredns-6cd4f4df4f-js84p                   1/1     Running   0               3m58s
kube-system   pod/exoscale-csi-controller-578ffbb766-l6gxz   7/7     Running   0               3m58s
kube-system   pod/exoscale-csi-controller-578ffbb766-wcqf6   7/7     Running   0               3m58s
kube-system   pod/exoscale-csi-node-rb8kp                    3/3     Running   1 (2m20s ago)   3m24s
kube-system   pod/exoscale-csi-node-xlmrn                    3/3     Running   0               3m24s
kube-system   pod/konnectivity-agent-6dcc98d849-jgh4h        1/1     Running   0               3m57s
kube-system   pod/konnectivity-agent-6dcc98d849-tmrv4        1/1     Running   0               3m57s
kube-system   pod/metrics-server-76f74c7d76-hw7sx            1/1     Running   0               3m57s
```