### PR TITLE
fix: add permission to delete-pod for karpenter role (after evict attempt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- fix(rbac): allow pod deletion (after an eviction was attempted and failed)
+
 1.36.1
 ------------------
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -138,13 +138,21 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - persistentvolumes
   - persistentvolumeclaims
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION

# Description

Add a section in rbac to allow `Pods` deletion by `karpenter` role

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
